### PR TITLE
JSON Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "sensio/distribution-bundle": "3.0.*",
         "twig/twig" : "1.18.*",
         "phpspec/php-diff": "1.0.*",
-        "google/apiclient": "1.1.*"
+        "google/apiclient": "1.1.*",
+        "seld/jsonlint" : "1.3.*"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b4e14a84a799d976144282e2ecd50972",
+    "hash": "c8b0fa26fd62aaee37b5618a1b1566d0",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1704,6 +1704,52 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21 13:59:46"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "863ae85c6d3ef60ca49cb12bd051c4a0648c40c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/863ae85c6d3ef60ca49cb12bd051c4a0648c40c4",
+                "reference": "863ae85c6d3ef60ca49cb12bd051c4a0648c40c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "time": "2015-01-04 21:18:15"
         },
         {
             "name": "sensio/distribution-bundle",

--- a/src/StackManagerBundle/Mapper/StackConfigMapper.php
+++ b/src/StackManagerBundle/Mapper/StackConfigMapper.php
@@ -16,6 +16,7 @@ use ROH\Bundle\StackManagerBundle\Model\Parameters;
 use ROH\Bundle\StackManagerBundle\Model\Stack;
 use ROH\Bundle\StackManagerBundle\Model\Template;
 use RuntimeException;
+use Seld\JsonLint\JsonParser;
 use Symfony\Component\Templating\EngineInterface;
 
 /**
@@ -100,7 +101,7 @@ class StackConfigMapper
             $this->scalingProfileParameters[$template][$scalingProfile]
         );
 
-        $body = json_decode($this->templating->render(
+        $body = (new JsonParser)->parse($this->templating->render(
             sprintf('%s.json.twig', $template),
             [
                 'environment' => $environment,
@@ -109,12 +110,6 @@ class StackConfigMapper
                 'rootStackName' => $name,
             ]
         ));
-        if ($body === null && json_last_error()) {
-            throw new RuntimeException(sprintf(
-                'Template body could not be decoded as JSON, error: %s',
-                json_last_error_msg()
-            ));
-        }
 
         $stack = new Stack(
             $name,


### PR DESCRIPTION
Use the Seldaek/jsonlint library to parse template bodies rather than PHP's built-in JSON functions, this returns much better error messages - previously it was almost impossible to debug syntax errors in the templates during development.
