### PR TITLE
Root stack name

### DIFF
--- a/src/StackManagerBundle/Mapper/StackConfigMapper.php
+++ b/src/StackManagerBundle/Mapper/StackConfigMapper.php
@@ -100,6 +100,9 @@ class StackConfigMapper
             $this->scalingProfileParameters[$template][$scalingProfile]
         );
 
+        $parameters['Environment'] = $environment;
+        $parameters['RootStackName'] = $name;
+
         $body = (new JsonParser())->parse($this->templating->render(
             sprintf('%s.json.twig', $template),
             [


### PR DESCRIPTION
Pass the environment and root stack name to all templates, so this can be fully propagated to all resources.
