### PR TITLE
Add option to watch stacks when updating

### DIFF
--- a/src/StackManagerBundle/Mapper/StackApiMapper.php
+++ b/src/StackManagerBundle/Mapper/StackApiMapper.php
@@ -12,11 +12,12 @@
 namespace ROH\Bundle\StackManagerBundle\Mapper;
 
 use Aws\CloudFormation;
-use DateTime;
+use DateTimeImmutable;
 use PHPUnit_Framework_Assert;
 use ROH\Bundle\StackManagerBundle\Model\Parameters;
-use ROH\Bundle\StackManagerBundle\Model\Stack;
+use ROH\Bundle\StackManagerBundle\Model\ApiStack;
 use ROH\Bundle\StackManagerBundle\Model\Template;
+use ROH\Bundle\StackManagerBundle\Model\Stack;
 use ROH\Bundle\StackManagerBundle\Service\TemplateExpansionService;
 
 /**
@@ -162,15 +163,15 @@ class StackApiMapper
             $response['LastUpdatedTime'] = $response['CreationTime'];
         }
 
-        return new Stack(
+        return new ApiStack(
             $name,
             $environment,
             new Template($templateName, $templateBodyCallback),
             Parameters::newFromCloudFormationResponseElement($response['Parameters']),
             $response['StackId'],
             $response['StackStatus'],
-            new DateTime($response['CreationTime']),
-            new DateTime($response['LastUpdatedTime'])
+            new DateTimeImmutable($response['CreationTime']),
+            new DateTimeImmutable($response['LastUpdatedTime'])
         );
     }
 }

--- a/src/StackManagerBundle/Mapper/StackEventApiMapper.php
+++ b/src/StackManagerBundle/Mapper/StackEventApiMapper.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Stack Manager package.
+ *
+ * © Royal Opera House Covent Garden Foundation <website@roh.org.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ROH\Bundle\StackManagerBundle\Mapper;
+
+use Aws\CloudFormation;
+use DateTimeInterface;
+use ROH\Bundle\StackManagerBundle\Model\Stack;
+use ROH\Bundle\StackManagerBundle\Model\StackEvent;
+
+/**
+ * Mapper to create stack event models from the CloudFormation API.
+ *
+ * @author Robert Leverington <robert.leverington@roh.org.uk>
+ */
+class StackEventApiMapper
+{
+    /**
+     * @var CloudFormation\CloudFormationClient
+     */
+    protected $cloudFormationClient;
+
+    public function __construct(CloudFormation\CloudFormationClient $cloudformationClient)
+    {
+        $this->cloudformationClient = $cloudformationClient;
+    }
+
+    /**
+     * Find the events for a stack that occur after a specified time.
+     *
+     * @param Stack $stack Stack to find events for.
+     * @param DateTimeInterface $afterTime Time to find events after.
+     * @return StackEvents[] Events occuring after the specified time, ordered
+     *     chronologically.
+     */
+    public function findStackEventAfterDateTime(Stack $stack, DateTimeInterface $afterTime)
+    {
+        $response = $this->cloudformationClient->DescribeStackEvents([
+            // Specifying the stack ID rather than name works for deleted
+            // stacks, so use that if it is available.
+            'StackName' => $stack instanceof ApiStack ? $stack->getId() : $stack->getName(),
+        ]);
+
+        $events = [];
+        foreach ($response['StackEvents'] as $responseEvent) {
+            $event = StackEvent::newFromApiResponseElement($stack, $responseEvent);
+            if ($event->getOccurranceTime() <= $afterTime) {
+                continue;
+            }
+
+            $events[] = $event;
+        }
+
+        // Stack events appear to be returned by the API in reverse
+        // chronological order, but this behaviour is undocumented, so order
+        // chronologically by comparing timestamps.
+        usort($events, function (StackEvent $eventA, StackEvent $eventB) {
+            return $eventA->getOccurranceTime() > $eventB->getOccurranceTime();
+        });
+
+        return $events;
+    }
+}

--- a/src/StackManagerBundle/Model/ApiStack.php
+++ b/src/StackManagerBundle/Model/ApiStack.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Stack Manager package.
+ *
+ * © Royal Opera House Covent Garden Foundation <website@roh.org.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ROH\Bundle\StackManagerBundle\Model;
+
+use DateTimeImmutable;
+use PHPUnit_Framework_Assert;
+
+/**
+ * Immutable model representing a CloudFormation stack that exists or existed in
+ * AWS.
+ *
+ * @author Robert Leverington <robert.leverington@roh.org.uk>
+ */
+class ApiStack extends Stack
+{
+    /**
+     * Id in CloudFormation.
+     *
+     * @var string|null
+     */
+    protected $id;
+
+    /**
+     * Status in CloudFormation.
+     *
+     * @var string|null
+     */
+    protected $status;
+
+    /**
+     * Creation time in CloudFormation.
+     *
+     * @var DateTimeImmutable|null
+     */
+    protected $creationTime;
+
+    /**
+     * Last updated time in CloudFormation.
+     *
+     * @var DateTimeImmutable|null
+     */
+    protected $lastUpdatedTime;
+
+    public function __construct(
+        $name,
+        $environment,
+        Template $template,
+        Parameters $parameters,
+        $id,
+        $status,
+        DateTimeImmutable $creationTime,
+        DateTimeImmutable $lastUpdatedTime
+    ) {
+        parent::__construct($name, $environment, $template, $parameters);
+
+        $this->id = $id;
+        $this->status = $status;
+        $this->creationTime = $creationTime;
+        $this->lastUpdatedTime = $lastUpdatedTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return DateTimeImmutable
+     */
+    public function getCreationTime()
+    {
+        return $this->creationTime;
+    }
+
+    /**
+     * @return DateTimeImmutable
+     */
+    public function getLastUpdatedTime()
+    {
+        return $this->lastUpdatedTime;
+    }
+}

--- a/src/StackManagerBundle/Model/Stack.php
+++ b/src/StackManagerBundle/Model/Stack.php
@@ -11,7 +11,6 @@
 
 namespace ROH\Bundle\StackManagerBundle\Model;
 
-use DateTime;
 use PHPUnit_Framework_Assert;
 
 /**
@@ -51,46 +50,11 @@ class Stack
      */
     protected $parameters;
 
-    /**
-     * Id in CloudFormation.  Only available for models created from the API.
-     *
-     * @var string|null
-     */
-    protected $id;
-
-    /**
-     * Status in CloudFormation.  Only available for models created from the
-     * API.
-     *
-     * @var string|null
-     */
-    protected $status;
-
-    /**
-     * Creation time in CloudFormation.  Only available for models created from
-     * the API.
-     *
-     * @var DateTime|null
-     */
-    protected $creationTime;
-
-    /**
-     * Last updated time in CloudFormation.  Only available for models created
-     * from the API.
-     *
-     * @var DateTime|null
-     */
-    protected $lastUpdatedTime;
-
     public function __construct(
         $name,
         $environment,
         Template $template,
-        Parameters $parameters,
-        $id = null,
-        $status = null,
-        DateTime $creationTime = null,
-        DateTime $lastUpdatedTime = null
+        Parameters $parameters
     ) {
         PHPUnit_Framework_Assert::assertInternalType(
             'string', $name,
@@ -117,10 +81,6 @@ class Stack
         $this->environment = $environment;
         $this->template = $template;
         $this->parameters = $parameters;
-        $this->id = $id;
-        $this->status = $status;
-        $this->creationTime = $creationTime;
-        $this->lastUpdatedTime = $lastUpdatedTime;
     }
 
     /**
@@ -164,26 +124,6 @@ class Stack
             self::ENVIRONMENT_TAG => $this->getEnvironment(),
             self::TEMPLATE_TAG => $this->getTemplate()->getName(),
         ]);
-    }
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    public function getCreationTime()
-    {
-        return $this->creationTime;
-    }
-
-    public function getLastUpdatedTime()
-    {
-        return $this->lastUpdatedTime;
     }
 
     /**

--- a/src/StackManagerBundle/Model/StackEvent.php
+++ b/src/StackManagerBundle/Model/StackEvent.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Stack Manager package.
+ *
+ * © Royal Opera House Covent Garden Foundation <website@roh.org.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ROH\Bundle\StackManagerBundle\Model;
+
+use DateTimeImmutable;
+use PHPUnit_Framework_Assert;
+
+/**
+ * Immutable model representing an event on a stack.
+ *
+ * @author Robert Leverington <robert.leverington@roh.org.uk>
+ */
+class StackEvent
+{
+    /**
+     * @var Stack
+     */
+    protected $stack;
+
+    /**
+     * @var DateTimeImmutable
+     */
+    protected $occurranceTime;
+
+    /**
+     * @var string
+     */
+    protected $resourceLogicalId;
+
+    /**
+     * @var string
+     */
+    protected $resourcePhysicalId;
+
+    /**
+     * @var string
+     */
+    protected $resourceType;
+
+    /**
+     * @var string
+     */
+    protected $resourceStatus;
+
+    /**
+     * @var string
+     */
+    protected $resourceStatusReason;
+
+    public function __construct(
+        Stack $stack,
+        DateTimeImmutable $occurranceTime,
+        $resourceLogicalId,
+        $resourcePhysicalId,
+        $resourceType,
+        $resourceStatus,
+        $resourceStatusReason
+    ) {
+        $this->stack = $stack;
+        $this->occurranceTime = $occurranceTime;
+        $this->resourceLogicalId = $resourceLogicalId;
+        $this->resourcePhysicalId = $resourcePhysicalId;
+        $this->resourceType = $resourceType;
+        $this->resourceStatus = $resourceStatus;
+        $this->resourceStatusReason = $resourceStatusReason;
+    }
+
+    public static function newFromApiResponseElement(Stack $stack, array $element)
+    {
+        $event = new StackEvent(
+            $stack,
+            new DateTimeImmutable($element['Timestamp']),
+            $element['LogicalResourceId'],
+            $element['PhysicalResourceId'],
+            $element['ResourceType'],
+            $element['ResourceStatus'],
+            isset($element['ResourceStatusReason']) ? $element['ResourceStatusReason'] : ''
+        );
+
+        return $event;
+    }
+
+    /**
+     * @return Stack
+     */
+    public function getStack()
+    {
+        return $this->stack;
+    }
+
+    /**
+     * @return DateTimeImmutable
+     */
+    public function getOccurranceTime()
+    {
+        return $this->occurranceTime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourceLogicalId()
+    {
+        return $this->resourceLogicalId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourcePhysicalId()
+    {
+        return $this->resourcePhysicalId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourceType()
+    {
+        return $this->resourceType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourceStatus()
+    {
+        return $this->resourceStatus;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourceStatusReason()
+    {
+        return $this->resourceStatusReason;
+    }
+}

--- a/src/StackManagerBundle/Resources/config/services.yml
+++ b/src/StackManagerBundle/Resources/config/services.yml
@@ -29,6 +29,7 @@ services:
             - @roh_stack_manager.mapper.stack_api
             - @roh_stack_manager.mapper.stack_config
             - @roh_stack_manager.service.stack_manager
+            - @roh_stack_manager.service.stack_watcher
         tags:
             - { name: console.command }
 
@@ -78,11 +79,21 @@ services:
             - %roh_stack_manager.environments%
             - %roh_stack_manager.scaling_profiles%
 
+    roh_stack_manager.mapper.stack_event_api:
+        class: ROH\Bundle\StackManagerBundle\Mapper\StackEventApiMapper
+        arguments:
+            - @aws.cloudformation
+
     roh_stack_manager.service.stack_manager:
         class: ROH\Bundle\StackManagerBundle\Service\StackManagerService
         arguments:
             - @roh_stack_manager.service.template_squashing
             - @aws.cloudformation
+
+    roh_stack_manager.service.stack_watcher:
+        class: ROH\Bundle\StackManagerBundle\Service\StackWatcherService
+        arguments:
+            - @roh_stack_manager.mapper.stack_event_api
 
     roh_stack_manager.service.stack_comparison:
         class: ROH\Bundle\StackManagerBundle\Service\StackComparisonService

--- a/src/StackManagerBundle/Service/StackWatcherService.php
+++ b/src/StackManagerBundle/Service/StackWatcherService.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Stack Manager package.
+ *
+ * © Royal Opera House Covent Garden Foundation <website@roh.org.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ROH\Bundle\StackManagerBundle\Service;
+
+use DateTimeImmutable;
+use ROH\Bundle\StackManagerBundle\Mapper\StackEventApiMapper;
+use ROH\Bundle\StackManagerBundle\Model\ApiStack;
+use ROH\Bundle\StackManagerBundle\Model\StackEvent;
+use ROH\Bundle\StackManagerBundle\Model\Stack;
+
+/**
+ * Service to watch CloudFromation stacks for updates.
+ *
+ * @author Robert Leverington <robert.leverington@roh.org.uk>
+ */
+class StackWatcherService
+{
+    /**
+     * @var StackEventApiMapper
+     */
+    protected $stackEventMapper;
+
+    /**
+     * @var string[] Events on the stack where watching should cease.
+     */
+    const BREAK_EVENTS = [
+        'CREATE_FAILED',
+        'CREATE_COMPLETE',
+        'DELETE_FAILED',
+        'DELETE_COMPLETE',
+        'ROLLBACK_FAILED',
+        'ROLLBACK_COMPLETE',
+        'UPDATE_COMPLETE',
+        'UPDATE_ROLLBACK_COMPLETE',
+        'UPDATE_ROLLBACK_FAILED',
+    ];
+
+    /**
+     * @var int Interval between checking for new stack events.
+     */
+    const POLL_INTERVAL = 5;
+
+    public function __construct(StackEventApiMapper $stackEventMapper)
+    {
+        $this->stackEventMapper = $stackEventMapper;
+    }
+
+    /**
+     * Poll stack events for a given stack and pass them to a callback until
+     * an appropriate event to break is seen on the stack itself.
+     *
+     * @param ApiStack $stack Stack to poll for events.
+     * @param callable $callback Callback to pass the StackEvent model to.
+     * @param string[] $breakEvents Events on the stack to stop watching after.
+     * @param int $pollInterval Interval between polling for stack events.
+     */
+    public function watch(
+        ApiStack $stack,
+        callable $callback,
+        $breakEvents = self::BREAK_EVENTS,
+        $pollInterval = self::POLL_INTERVAL
+    ) {
+        $afterTime = new DateTimeImmutable;
+
+        while (true) {
+            $events = $this->stackEventMapper->findStackEventAfterDateTime($stack, $afterTime);
+
+            foreach ($events as $event) {
+                $callback($event);
+
+                if ($event->getResourcePhysicalId() === $stack->getId()
+                    && in_array($event->getResourceStatus(), $breakEvents)
+                ) {
+                    return;
+                }
+            }
+
+            // Check for new events that occur after the time of the last event.
+            if (isset($event)) {
+                $afterTime = $event->getOccurranceTime();
+            }
+
+            sleep($pollInterval);
+        }
+    }
+}


### PR DESCRIPTION
- Move properties of the Stack model that are only available via the API in to a separate ApiStack model.
- Add a service that polls for stack events and passes them to a callback until a certain stack event is seen.
