### PR TITLE
Fix exception re-throw.

### DIFF
--- a/src/StackManagerBundle/TwigExtension/CloudFormationTwigExtension.php
+++ b/src/StackManagerBundle/TwigExtension/CloudFormationTwigExtension.php
@@ -83,7 +83,7 @@ class CloudFormationTwigExtension extends Twig_Extension
             if (preg_match('#Stack \'.*?\' does not exist#', $e->getMessage())) {
                 return null;
             }
-            throw new $e;
+            throw $e;
         }
 
         if (!isset($response['StackResourceDetail'])) {


### PR DESCRIPTION
This catch block was causing another error because it was trying to instantiate an AwsException with no message.
